### PR TITLE
Detect boot failures and re-attempt up to `reboot_error_threshold` times

### DIFF
--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -237,6 +237,8 @@ class CreateVM(State):
             return StopVM(self.params)
         elif self.vm.state == vm_manager.ERROR:
             return CalcAction(self.params)
+        elif self.vm.state == vm_manager.DOWN:
+            return CreateVM(self.params)
         return CheckBoot(self.params)
 
 

--- a/akanda/rug/test/unit/test_main.py
+++ b/akanda/rug/test/unit/test_main.py
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import sys
 import socket
 
 import mock
@@ -103,6 +104,10 @@ class TestMainPippo(unittest.TestCase):
 @mock.patch('akanda.rug.api.quantum.get_local_service_ip')
 class TestMainExtPortBinding(unittest.TestCase):
 
+    @unittest.skipIf(
+        sys.platform != 'linux2',
+        'unsupported platform'
+    )
     def test_ensure_local_port_host_binding(
             self, get_local_service_ip, shuffle_notifications, health,
             populate, scheduler, notifications, multiprocessing,

--- a/akanda/rug/test/unit/test_state.py
+++ b/akanda/rug/test/unit/test_state.py
@@ -280,11 +280,22 @@ class TestCreateVMState(BaseTestStateCase):
         self._test_transition_hlpr(
             event.READ,
             state.CheckBoot,
-            vm_manager.DOWN
+            vm_manager.BOOTING
         )
 
     def test_transition_vm_up(self):
-        self._test_transition_hlpr(event.READ, state.CheckBoot)
+        self._test_transition_hlpr(
+            event.READ,
+            state.CheckBoot,
+            vm_state=state.vm_manager.BOOTING
+        )
+
+    def test_transition_vm_missing(self):
+        self._test_transition_hlpr(
+            event.READ,
+            state.CreateVM,
+            vm_state=state.vm_manager.DOWN
+        )
 
     def test_transition_vm_error(self):
         self._test_transition_hlpr(event.READ, state.CalcAction,

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -202,6 +202,7 @@ class VmManager(object):
         else:
             # We have successfully started a (re)boot attempt so
             # record the timestamp so we can report how long it takes.
+            self.state = BOOTING
             self.last_boot = datetime.utcnow()
             self._currently_booting = True
 

--- a/doc/source/state_machine.dot
+++ b/doc/source/state_machine.dot
@@ -30,6 +30,7 @@ digraph rug {
   CREATE_VM -> CHECK_BOOT [ label = "ACT:[CRUDP],vm:[DBUCR]" ];
   CREATE_VM -> STOP_VM [ label = "vm:G" ];
   CREATE_VM -> CALC_ACTION [ label = "vm:E" ];
+  CREATE_VM -> CREATE_VM [ label = "vm:D" ];
 
   CHECK_BOOT -> CONFIG [ label = "vm>U" ];
   CHECK_BOOT -> CALC_ACTION [ label = "vm:[BCR]" ];


### PR DESCRIPTION
If calls to boot a router fail (e.g., Nova or Neutron return an HTTP 500 during
the plug + boot process), the state machine goes into CheckBoot state and polls
the router's management address to check for aliveness.  This causes a needless
polling process (because the VM will never boot).

Instead, the CreateVM step should make sure that a VM was _actually created_
before proceeding to the CheckBoot step.  If not, CreateVM should transition
_back_ to CreateVM (up to `reboot_error_threshold` times, until the router is
placed into ERROR state).
