### PR TITLE
Set dhcp to false for ipv6 subnets if slaac is enabled

### DIFF
--- a/akanda/rug/api/configuration.py
+++ b/akanda/rug/api/configuration.py
@@ -179,7 +179,7 @@ def _interface_config(ifname, port, subnets_dict):
 def _subnet_config(subnet):
     return {
         'cidr': str(subnet.cidr),
-        'dhcp_enabled': subnet.enable_dhcp,
+        'dhcp_enabled': subnet.enable_dhcp and subnet.ipv6_ra_mode != 'slaac',
         'dns_nameservers': subnet.dns_nameservers,
         'host_routes': subnet.host_routes,
         'gateway_ip': (str(subnet.gateway_ip)

--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -133,7 +133,8 @@ class Router(object):
 
 class Subnet(object):
     def __init__(self, id_, name, tenant_id, network_id, ip_version, cidr,
-                 gateway_ip, enable_dhcp, dns_nameservers, host_routes):
+                 gateway_ip, enable_dhcp, dns_nameservers, host_routes,
+                 ipv6_ra_mode):
         self.id = id_
         self.name = name
         self.tenant_id = tenant_id
@@ -156,6 +157,7 @@ class Subnet(object):
         self.enable_dhcp = enable_dhcp
         self.dns_nameservers = dns_nameservers
         self.host_routes = host_routes
+        self.ipv6_ra_mode = ipv6_ra_mode
 
     @classmethod
     def from_dict(cls, d):
@@ -169,7 +171,8 @@ class Subnet(object):
             d['gateway_ip'],
             d['enable_dhcp'],
             d['dns_nameservers'],
-            d['host_routes'])
+            d['host_routes'],
+            d['ipv6_ra_mode'])
 
 
 class Port(object):

--- a/akanda/rug/test/unit/api/test_configuration.py
+++ b/akanda/rug/test/unit/api/test_configuration.py
@@ -21,6 +21,7 @@ from oslo.config import cfg
 import unittest2 as unittest
 
 from akanda.rug.api import configuration as conf_mod
+from akanda.rug.api.quantum import Subnet
 
 
 class FakeModel(object):
@@ -64,6 +65,20 @@ fake_subnet = FakeModel(
     gateway_ip='192.168.1.1',
     enable_dhcp=True,
     dns_nameservers=['8.8.8.8'],
+    ipv6_ra_mode=None,
+    host_routes={})
+
+fake_subnet_with_slaac = Subnet(
+    id_='fake_id',
+    name='s1',
+    tenant_id='fake_tenant_id',
+    network_id='fake_network_id',
+    ip_version=6,
+    cidr='fdee:9f85:83be::/48',
+    gateway_ip='fdee:9f85:83be::1',
+    enable_dhcp=True,
+    dns_nameservers=['8.8.8.8'],
+    ipv6_ra_mode='slaac',
     host_routes={})
 
 fake_router = FakeModel(
@@ -286,6 +301,17 @@ class TestAkandaClient(unittest.TestCase):
         }
         self.assertEqual(conf_mod._subnet_config(fake_subnet), expected)
 
+    def test_subnet_config_with_slaac_enabled(self):
+        expected = {
+            'cidr': 'fdee:9f85:83be::/48',
+            'dhcp_enabled': False,
+            'dns_nameservers': ['8.8.8.8'],
+            'gateway_ip': 'fdee:9f85:83be::1',
+            'host_routes': {}
+        }
+        self.assertEqual(
+            conf_mod._subnet_config(fake_subnet_with_slaac), expected)
+
     def test_subnet_config_no_gateway(self):
         expected = {
             'cidr': '192.168.1.0/24',
@@ -300,6 +326,7 @@ class TestAkandaClient(unittest.TestCase):
             gateway_ip='',
             enable_dhcp=True,
             dns_nameservers=['8.8.8.8'],
+            ipv6_ra_mode='',
             host_routes={})
         self.assertEqual(conf_mod._subnet_config(sn), expected)
 
@@ -317,6 +344,7 @@ class TestAkandaClient(unittest.TestCase):
             gateway_ip=None,
             enable_dhcp=True,
             dns_nameservers=['8.8.8.8'],
+            ipv6_ra_mode='',
             host_routes={})
         self.assertEqual(conf_mod._subnet_config(sn), expected)
 

--- a/akanda/rug/test/unit/api/test_quantum_wrapper.py
+++ b/akanda/rug/test/unit/api/test_quantum_wrapper.py
@@ -99,6 +99,7 @@ class TestQuantumModels(unittest.TestCase):
             'gateway_ip': 'fe80::1',
             'enable_dhcp': True,
             'dns_nameservers': ['8.8.8.8', '8.8.4.4'],
+            'ipv6_ra_mode': 'slaac',
             'host_routes': []
         }
 
@@ -126,6 +127,7 @@ class TestQuantumModels(unittest.TestCase):
             'gateway_ip': None,
             'enable_dhcp': True,
             'dns_nameservers': ['8.8.8.8', '8.8.4.4'],
+            'ipv6_ra_mode': 'slaac',
             'host_routes': []
         }
         s = quantum.Subnet.from_dict(d)
@@ -143,6 +145,7 @@ class TestQuantumModels(unittest.TestCase):
             'gateway_ip': 'something-that-is-not-an-ip',
             'enable_dhcp': True,
             'dns_nameservers': ['8.8.8.8', '8.8.4.4'],
+            'ipv6_ra_mode': 'slaac',
             'host_routes': []
         }
         s = quantum.Subnet.from_dict(d)
@@ -160,6 +163,7 @@ class TestQuantumModels(unittest.TestCase):
             'gateway_ip': 'fe80::1',
             'enable_dhcp': True,
             'dns_nameservers': ['8.8.8.8', '8.8.4.4'],
+            'ipv6_ra_mode': 'slaac',
             'host_routes': []
         }
         try:
@@ -178,6 +182,7 @@ class TestQuantumModels(unittest.TestCase):
             'gateway_ip': 'fe80::1',
             'enable_dhcp': True,
             'dns_nameservers': ['8.8.8.8', '8.8.4.4'],
+            'ipv6_ra_mode': 'slaac',
             'host_routes': []
         }
         try:
@@ -348,10 +353,10 @@ class TestExternalPort(unittest.TestCase):
     SUBNETS = [
         quantum.Subnet(u'ipv4snid', u'ipv4snid', None, None, 4,
                        '172.16.77.0/24', '172.16.77.1', False,
-                       [], []),
+                       [], [], None),
         quantum.Subnet(u'ipv6snid', u'ipv4snid', None, None, 6,
                        'fdee:9f85:83be::/48', 'fdee:9f85:83be::1',
-                       False, [], []),
+                       False, [], [], None),
     ]
 
     def setUp(self):


### PR DESCRIPTION
The akanda-appliance sets `autonomous` to off in the
bird6 conf if dhcp is enabled. Neutron forces to enable
dhcp even on ipv6 subnets that use slaac, so as result,
vms are not getting any reply to router sollecitation
requests.

Change-Id: If3d8453f865b20bacdacebff5d74e18f7ac627de
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
