### PR TITLE
stable/juno Backports

### DIFF
--- a/akanda/rug/cli/app.py
+++ b/akanda/rug/cli/app.py
@@ -31,18 +31,22 @@ class RugController(app.App):
 
     log = logging.getLogger(__name__)
 
-    def __init__(self):
+    def __init__(self, stdout=None):
         dist = pkg_resources.get_distribution('akanda-rug')
         super(RugController, self).__init__(
             description='controller for the Akanda RUG service',
             version=dist.version,
             command_manager=commandmanager.CommandManager('akanda.rug.cli'),
+            stdout=stdout
         )
 
     def initialize_app(self, argv):
         # Quiet logging for some request library
         logging.getLogger('requests').setLevel(logging.WARN)
-        main.register_and_load_opts()
+        try:
+            main.register_and_load_opts()
+        except cfg.ArgsAlreadyParsedError:
+            pass
         # Don't pass argv here because cfg.CONF will intercept the
         # help options and exit.
         cfg.CONF(['--config-file', '/etc/akanda-rug/rug.ini'],

--- a/akanda/rug/cli/router.py
+++ b/akanda/rug/cli/router.py
@@ -17,17 +17,26 @@
 
 """Commands related to routers.
 """
+from __future__ import print_function
+
 import argparse
+import logging
+import multiprocessing
 import subprocess
 import sys
+import thread
+import threading
+import time
+from collections import namedtuple, deque
 
 from akanda.rug import commands
 from akanda.rug.cli import message
 from akanda.rug.api import nova, quantum
 
+from cliff import command
+from neutronclient.v2_0 import client
 from novaclient import exceptions
 from oslo.config import cfg
-from neutronclient.v2_0 import client
 
 
 class _TenantRouterCmd(message.MessageSending):
@@ -132,6 +141,192 @@ class RouterManage(_TenantRouterCmd):
     """manage a single router"""
 
     _COMMAND = commands.ROUTER_MANAGE
+
+
+class RouterBatchedRebuild(command.Command):
+    """rebuild every akanda router in batches"""
+
+    THREAD_SHUTDOWN = threading.Event()
+    Router = namedtuple('Router', ('id', 'name'))
+
+    queue = deque()
+    active = deque()
+
+    def __init__(self, *args, **kw):
+        logging.getLogger('urllib3').setLevel(logging.ERROR)
+        super(RouterBatchedRebuild, self).__init__(*args, **kw)
+
+    def cprint(self, msg, color='green'):
+        try:
+            import blessed
+            term = blessed.Terminal()
+            print(getattr(term, color)(msg), file=self.app.stdout)
+        except ImportError:
+            print(msg, file=self.app.stdout)
+
+    @property
+    def neutron(self):
+        return client.Client(
+            username=self.app.rug_ini.admin_user,
+            password=self.app.rug_ini.admin_password,
+            tenant_name=self.app.rug_ini.admin_tenant_name,
+            auth_url=self.app.rug_ini.auth_url,
+            auth_strategy=self.app.rug_ini.auth_strategy,
+            region_name=self.app.rug_ini.auth_region,
+        )
+
+    @property
+    def nova(self):
+        return nova.Nova(cfg.CONF)
+
+    def get_instance(self, router):
+        router = RouterBatchedRebuild.Router(
+            id=router['id'], name=router['name']
+        )
+        return self.nova.get_instance(router)
+
+    def get_parser(self, prog_name):
+        p = super(RouterBatchedRebuild, self).get_parser(prog_name)
+        p.add_argument('--batch', action="store", type=int, default=15)
+        return p
+
+    @classmethod
+    def chunked(cls, l, n):
+        for i in xrange(0, len(l), n):
+            yield l[i:i+n]
+
+    def take_action(self, parsed_args):
+        batch = parsed_args.batch
+
+        logging.getLogger('akanda.rug.cli.message').setLevel(logging.ERROR)
+        self.cprint("Restarting routers in batches of %s..." % batch, 'blue')
+
+        threads = self.spawn_threads()
+
+        for chunk in RouterBatchedRebuild.chunked(
+            self.neutron.list_routers()['routers'], batch
+        ):
+            self.queue.clear()
+            self.active.clear()
+            rebooting = []
+            for router in chunk:
+                server = self.get_instance(router)
+                if not server:
+                    self.cprint("No VM found for %s!" % router['id'], 'red')
+                elif self.app.rug_ini.router_image_uuid == server.image['id']:
+                    self.cprint("Router %s is already up-to-date, skipping!"
+                                % router['id'], 'green')
+                    continue
+                self.cprint(
+                    "Rebuilding %s %s..." % (router['id'], router['name']),
+                    'yellow'
+                )
+                rebooting.append(router)
+
+            if not rebooting:
+                continue
+
+            self.queue.extend(rebooting)
+            for router in rebooting:
+                self.app.run(['--debug', 'router', 'rebuild', router['id']])
+
+            total = len(rebooting)
+            self.cprint(
+                "Waiting on %s routers to become ACTIVE....<Ctrl-C to skip>" %
+                total,
+                'blue'
+            )
+            try:
+                while len(self.active) < len(rebooting):
+                    new_total = len(rebooting) - len(self.active)
+                    if total != new_total:
+                        total = new_total
+                        if total:
+                            self.cprint(
+                                "Waiting on %s routers to become "
+                                "ACTIVE....<Ctrl-C to skip>" % total,
+                                'blue'
+                            )
+                            time.sleep(5)
+            except KeyboardInterrupt:
+                try:
+                    self.cprint(
+                        "\nContinuing with next batch of routers...",
+                        'blue'
+                    )
+                    continue
+                except KeyboardInterrupt:
+                    continue
+
+        self.cprint("Waiting on worker threads to finish...", 'yellow')
+        RouterBatchedRebuild.THREAD_SHUTDOWN.set()
+        for t in threads:
+            t.join()
+
+    def spawn_threads(self):
+        """
+        Spawn a number of worker threads to monitor Neutron routers for
+        ALIVEness.
+        """
+        threads = []
+        for i in range(multiprocessing.cpu_count()):
+            t = threading.Thread(
+                target=self.check_alive, args=(self.queue, self.active)
+            )
+            t.daemon = True
+            t.start()
+            threads.append(t)
+
+        self.cprint('Spawned %d worker threads!' % len(threads), 'blue')
+        return threads
+
+    def check_alive(self, queue, active):
+        """
+        Thread worker that iterates over a queue of routers and waits for the
+        underlying VM to change and become ACTIVE.
+
+        :param queue: a collection of Neutron router dicts
+        :type queue: collections.deque
+        :param active: a thread-safe collections.deque used for tracking
+                       routers which have successfully rebuilt
+        :type active: collections.deque
+        """
+        logging.getLogger('urllib3').setLevel(logging.CRITICAL)
+
+        def pop():
+            router = None
+            while router is None:
+                if RouterBatchedRebuild.THREAD_SHUTDOWN.is_set():
+                    return None, None
+                try:
+                    router = queue.pop()
+                except IndexError:
+                    time.sleep(1)
+            return router, getattr(self.get_instance(router), 'id', None)
+
+        router, old_uuid = pop()
+
+        while router and not RouterBatchedRebuild.THREAD_SHUTDOWN.is_set():
+            router = self.neutron.show_router(
+                router['id']).get('router', {})
+            server = self.get_instance(router)
+            if not server:  # VM exists
+                continue
+            if server.status != 'ACTIVE':  # VM is ACTIVE
+                continue
+            changed = old_uuid != server.id
+            if not changed:  # VM uuid actually changed
+                continue
+            if router['status'] != 'ACTIVE':  # Router is ACTIVE
+                continue
+            self.cprint(
+                "%s is ACTIVE, new VM is %s" % (router['id'], server.id),
+                'green'
+            )
+            active.append(router)
+            router, old_uuid = pop()
+
+        self.cprint('Thread %d is exiting...' % thread.get_ident(), 'yellow')
 
 
 class RouterSSH(_TenantRouterCmd):

--- a/akanda/rug/test/unit/cli/test_router.py
+++ b/akanda/rug/test/unit/cli/test_router.py
@@ -61,14 +61,14 @@ class TestRouterBatchedRebuild(FunctionalTest):
 
     @mock.patch.object(router.RouterBatchedRebuild, 'neutron')
     @mock.patch.object(router.RouterBatchedRebuild, 'spawn_threads',
-                       lambda self: [])
+                       lambda self, threads: [])
     def test_no_routers(self, neutron):
         neutron.list_routers.return_value = {'routers': []}
         self.app.run(['--debug', 'batch', 'rebuild'])
         assert "routers to become ACTIVE" not in self.stdout.getvalue()
 
     @mock.patch.object(router.RouterBatchedRebuild, 'spawn_threads',
-                       lambda self: [])
+                       lambda self, threads: [])
     @mock.patch.object(router.RouterBatchedRebuild, 'get_instance', lambda *a:
                        None)
     @mock.patch.object(router.RouterBatchedRebuild, 'neutron')
@@ -88,7 +88,7 @@ class TestRouterBatchedRebuild(FunctionalTest):
         assert rebuild.call_count == 1
 
     @mock.patch.object(router.RouterBatchedRebuild, 'spawn_threads',
-                       lambda self: [])
+                       lambda self, threads: [])
     @mock.patch.object(router.RouterBatchedRebuild, 'get_instance', lambda *a:
                        mock.Mock(image={'id': 'LATEST'}))
     @mock.patch.object(router.RouterBatchedRebuild, 'neutron')
@@ -100,7 +100,7 @@ class TestRouterBatchedRebuild(FunctionalTest):
         assert "Router 123 is already up-to-date" in self.stdout.getvalue()
 
     @mock.patch.object(router.RouterBatchedRebuild, 'spawn_threads',
-                       lambda self: [])
+                       lambda self, threads: [])
     @mock.patch.object(router.RouterBatchedRebuild, 'get_instance', lambda *a:
                        mock.Mock(image={'id': 'OUT-OF-DATE'}))
     @mock.patch.object(router.RouterBatchedRebuild, 'neutron')

--- a/akanda/rug/test/unit/cli/test_router.py
+++ b/akanda/rug/test/unit/cli/test_router.py
@@ -1,0 +1,189 @@
+from collections import namedtuple, deque
+from cStringIO import StringIO
+import unittest
+
+import mock
+
+from akanda.rug.cli import app
+from akanda.rug.cli import router
+
+
+class FunctionalTest(unittest.TestCase):
+
+    def setUp(self):
+        rug = namedtuple('rugcfg', [
+            'admin_user', 'admin_password', 'admin_tenant_name', 'auth_url',
+            'auth_strategy', 'auth_region', 'router_image_uuid'
+        ])
+
+        class RugController(app.RugController):
+
+            def __init__(self, stdout):
+                super(RugController, self).__init__(stdout=stdout)
+
+            def initialize_app(self, argv):
+                pass
+
+            @property
+            def rug_ini(self):
+                return rug(**{
+                    'admin_user': 'neutron',
+                    'admin_password': 'secret',
+                    'admin_tenant_name': 'service',
+                    'auth_url': 'http://locahost',
+                    'auth_strategy': 'keystone',
+                    'auth_region': 'default',
+                    'router_image_uuid': 'LATEST'
+                })
+
+        self.stdout = StringIO()
+        self.app = RugController(stdout=self.stdout)
+
+    def tearDown(self):
+        del self.app
+
+
+class TestRouterBatchedRebuild(FunctionalTest):
+
+    def setUp(self):
+        super(TestRouterBatchedRebuild, self).setUp()
+        router.RouterBatchedRebuild.THREAD_SHUTDOWN.clear()
+
+    def test_chunked(self):
+        chunks_gen = router.RouterBatchedRebuild.chunked(range(50), 10)
+        assert list(chunks_gen) == [
+            range(0, 10),
+            range(10, 20),
+            range(20, 30),
+            range(30, 40),
+            range(40, 50),
+        ]
+
+    @mock.patch.object(router.RouterBatchedRebuild, 'neutron')
+    @mock.patch.object(router.RouterBatchedRebuild, 'spawn_threads',
+                       lambda self: [])
+    def test_no_routers(self, neutron):
+        neutron.list_routers.return_value = {'routers': []}
+        self.app.run(['--debug', 'batch', 'rebuild'])
+        assert "routers to become ACTIVE" not in self.stdout.getvalue()
+
+    @mock.patch.object(router.RouterBatchedRebuild, 'spawn_threads',
+                       lambda self: [])
+    @mock.patch.object(router.RouterBatchedRebuild, 'get_instance', lambda *a:
+                       None)
+    @mock.patch.object(router.RouterBatchedRebuild, 'neutron')
+    @mock.patch.object(router.RouterRebuild, 'take_action')
+    def test_router_vm_is_missing(self, rebuild, neutron):
+        r = {'id': '123', 'name': 'ak-456', 'status': 'ACTIVE'}
+        neutron.list_routers.return_value = {'routers': [r]}
+
+        with mock.patch.object(
+            router.RouterBatchedRebuild, 'active',
+            mock.Mock(__len__=lambda self: 1)
+        ):
+            self.app.run(['--debug', 'batch', 'rebuild'])
+
+        assert "No VM found for 123" in self.stdout.getvalue()
+        assert "Rebuilding 123 ak-456" in self.stdout.getvalue()
+        assert rebuild.call_count == 1
+
+    @mock.patch.object(router.RouterBatchedRebuild, 'spawn_threads',
+                       lambda self: [])
+    @mock.patch.object(router.RouterBatchedRebuild, 'get_instance', lambda *a:
+                       mock.Mock(image={'id': 'LATEST'}))
+    @mock.patch.object(router.RouterBatchedRebuild, 'neutron')
+    def test_router_image_is_latest(self, neutron):
+        neutron.list_routers.return_value = {
+            'routers': [{'id': '123', 'name': 'ak-456', 'status': 'ACTIVE'}]
+        }
+        self.app.run(['--debug', 'batch', 'rebuild'])
+        assert "Router 123 is already up-to-date" in self.stdout.getvalue()
+
+    @mock.patch.object(router.RouterBatchedRebuild, 'spawn_threads',
+                       lambda self: [])
+    @mock.patch.object(router.RouterBatchedRebuild, 'get_instance', lambda *a:
+                       mock.Mock(image={'id': 'OUT-OF-DATE'}))
+    @mock.patch.object(router.RouterBatchedRebuild, 'neutron')
+    @mock.patch.object(router.RouterRebuild, 'take_action')
+    def test_router_out_of_date(self, rebuild, neutron):
+        r = {'id': '123', 'name': 'ak-456', 'status': 'ACTIVE'}
+        neutron.list_routers.return_value = {'routers': [r]}
+
+        with mock.patch.object(
+            router.RouterBatchedRebuild, 'active',
+            mock.Mock(__len__=lambda self: 1)
+        ):
+            self.app.run(['--debug', 'batch', 'rebuild'])
+        assert "Rebuilding 123 ak-456" in self.stdout.getvalue()
+        assert rebuild.call_count == 1
+
+    @mock.patch.object(router.RouterBatchedRebuild, 'neutron')
+    @mock.patch.object(router.RouterBatchedRebuild, 'get_instance')
+    def test_check_alive_vm_rebooting(self, get_instance, neutron):
+        r = {'id': '123', 'name': 'ak-456', 'status': 'ACTIVE'}
+
+        def gen_instance():
+            for m in (
+                mock.Mock(id='123', status='ACTIVE'),
+                None,
+                mock.Mock(id='456', status='DOWN'),
+                mock.Mock(id='456', status='BUILD'),
+            ):
+                yield m
+
+            router.RouterBatchedRebuild.THREAD_SHUTDOWN.set()
+            yield mock.Mock(id='456', status='ACTIVE')
+
+        _gen = gen_instance()
+        get_instance.side_effect = lambda *a, **kw: _gen.next()
+
+        neutron.show_router.return_value = {'router': r}
+        router.RouterBatchedRebuild(self.app, [], '').check_alive([r], deque())
+        assert neutron.show_router.call_count == 4
+
+    @mock.patch.object(router.RouterBatchedRebuild, 'neutron')
+    @mock.patch.object(router.RouterBatchedRebuild, 'get_instance')
+    def test_check_alive_new_vm_booting(self, get_instance, neutron):
+        r = {'id': '123', 'name': 'ak-456', 'status': 'ACTIVE'}
+
+        def gen_instance():
+            for m in (
+                None,
+                None,
+                None,
+                None,
+                mock.Mock(id='123', status='DOWN'),
+                mock.Mock(id='123', status='BUILD'),
+            ):
+                yield m
+
+            router.RouterBatchedRebuild.THREAD_SHUTDOWN.set()
+            yield mock.Mock(id='123', status='ACTIVE')
+
+        _gen = gen_instance()
+        get_instance.side_effect = lambda *a, **kw: _gen.next()
+
+        neutron.show_router.return_value = {'router': r}
+        router.RouterBatchedRebuild(self.app, [], '').check_alive([r], deque())
+        assert neutron.show_router.call_count == 6
+
+    @mock.patch.object(router.RouterBatchedRebuild, 'neutron')
+    @mock.patch.object(router.RouterBatchedRebuild, 'get_instance')
+    def test_check_alive_keyboard_interrupt(self, get_instance, neutron):
+        r = {'id': '123', 'name': 'ak-456', 'status': 'DOWN'}
+
+        def gen_instance():
+            yield mock.Mock(id='123', status='DOWN')
+            for m in range(9):
+                yield None
+
+            # Simulate a KeyboardInterrupt
+            router.RouterBatchedRebuild.THREAD_SHUTDOWN.set()
+            yield None
+
+        _gen = gen_instance()
+        get_instance.side_effect = lambda *a, **kw: _gen.next()
+
+        neutron.show_router.return_value = {'router': r}
+        router.RouterBatchedRebuild(self.app, [], '').check_alive([r], deque())
+        assert neutron.show_router.call_count == 10

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -390,7 +390,12 @@ class VmManager(object):
                     self.log.debug(
                         'New port %s, %s found, plugging...' % (port.id, mac)
                     )
-                    instance.interface_attach(port.id, None, None)
+                    try:
+                        instance.interface_attach(port.id, None, None)
+                    except:
+                        self.log.exception('Interface attach failed')
+                        self.state = RESTART
+                        return
 
             # For each *extra* mac address on the VM...
             for mac in actual_macs - expected_macs:
@@ -412,7 +417,12 @@ class VmManager(object):
                             'Port %s, %s is detached from ' % (port.id, mac),
                             'the neutron router, unplugging...'
                         ]))
-                        instance.interface_detach(port.id)
+                        try:
+                            instance.interface_detach(port.id)
+                        except:
+                            self.log.exception('Interface detach failed')
+                            self.state = RESTART
+                            return
                         ports_to_delete.append(port)
 
         # The action of attaching/detaching interfaces in Nova happens via the

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ akanda.rug.cli =
     tenant debug=akanda.rug.cli.tenant:TenantDebug
     tenant manage=akanda.rug.cli.tenant:TenantManage
     workers debug=akanda.rug.cli.worker:WorkerDebug
+    batch rebuild=akanda.rug.cli.router:RouterBatchedRebuild
     browse=akanda.rug.cli.browse:BrowseRouters
     poll=akanda.rug.cli.poll:Poll
     ssh=akanda.rug.cli.router:RouterSSH


### PR DESCRIPTION
61c6058 Capture and gracefully handle failed interface attach/detach replug calls.
a1768c2 Add a rug-ctl command for rebuilding every router in (configurable) batches.
d74d628 Don't spawn any more threads than `rug-ctl batch rebuild` needs.
