### PR TITLE
Use a standard hostname to prevent setting invalid hostnames.

### DIFF
--- a/akanda/rug/api/configuration.py
+++ b/akanda/rug/api/configuration.py
@@ -57,7 +57,7 @@ def build_config(client, router, interfaces):
         'labels': provider_rules.get('labels', {}),
         'floating_ips': generate_floating_config(router),
         'tenant_id': router.tenant_id,
-        'hostname': router.name
+        'hostname': 'ak-%s' % router.tenant_id
     }
 
 

--- a/akanda/rug/test/unit/api/test_configuration.py
+++ b/akanda/rug/test/unit/api/test_configuration.py
@@ -147,7 +147,7 @@ class TestAkandaClient(unittest.TestCase):
                 'asn': 64512,
                 'neighbor_asn': 64512,
                 'tenant_id': 'tenant_id',
-                'hostname': 'router_name'
+                'hostname': 'ak-tenant_id'
             }
 
             self.assertEqual(config, expected)


### PR DESCRIPTION
It's possible for a tenant to change their router's name to something that's
not a valid hostname.  This uses a standard ak-<tenant-uuid> value that we can
rely on.
